### PR TITLE
Allow queries without batch keys

### DIFF
--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -335,6 +335,10 @@ if Code.ensure_loaded?(Ecto) do
       end
     end
 
+    defp load_rows(nil, _inputs, _queryable, query, repo, repo_opts) do
+      repo.all(query, repo_opts)
+    end
+
     defp load_rows(col, inputs, queryable, query, repo, repo_opts) do
       pk = queryable.__schema__(:primary_key)
 
@@ -570,6 +574,10 @@ if Code.ensure_loaded?(Ecto) do
             This can happen if you intend to pass an Ecto struct in your call to
             `dataloader/4` but pass something other than a struct.
           """
+      end
+
+      defp normalize_value(_queryable, []) do
+        {:not_primary, nil, nil}
       end
 
       defp normalize_value(queryable, [{col, value}]) do

--- a/test/dataloader/ecto_test.exs
+++ b/test/dataloader/ecto_test.exs
@@ -308,6 +308,26 @@ defmodule Dataloader.EctoTest do
     assert message =~ "Cardinality"
   end
 
+  test "basic loading of all things", %{loader: loader} do
+    user1 = %User{username: "Ben Wilson"} |> Repo.insert!()
+    user2 = %User{username: "Bruce Williams"} |> Repo.insert!()
+
+    [post1, post2, post3] =
+      [
+        %Post{user_id: user1.id, title: "foo"},
+        %Post{user_id: user1.id, title: "baz"},
+        %Post{user_id: user2.id, title: "bar"}
+      ]
+      |> Enum.map(&Repo.insert!/1)
+
+    loader =
+      loader
+      |> Dataloader.load(Test, {:many, Post}, [])
+      |> Dataloader.run()
+
+    assert [post1, post2, post3] == Dataloader.get(loader, Test, {:many, Post}, [])
+  end
+
   describe "many_to_many" do
     test "basic loading works", %{loader: loader} do
       user1 = %User{username: "Ben Wilson"} |> Repo.insert!()


### PR DESCRIPTION
I have a use case where a query should run in dataloader without batching, together with all other (possibly batched) queries.

A few examples (see tests added in this PR):

```elixir
# all entries in the table
Dataloader.load(Test, {:many, Post}, [])

# first entry in the entire table
Dataloader.load(Test, {:one, Post, limit: 1, order_by: [asc: :id]}, [])
```

The changes needed are minimal.

I'm happy to make another PR for the v1 branch, if and when this gets merged.

Thanks a lot for your consideration! 🙏