### PR TITLE
Revert undesirable lateral

### DIFF
--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -695,7 +695,7 @@ if Code.ensure_loaded?(Ecto) do
         records = records |> Enum.map(&Map.put(&1, field, empty))
 
         results =
-          if query.limit || query.offset || Enum.any?(query.order_bys) do
+          if query.limit || query.offset do
             records
             |> preload_lateral(field, query, source.repo, repo_opts)
           else

--- a/test/dataloader/ecto_test.exs
+++ b/test/dataloader/ecto_test.exs
@@ -308,7 +308,7 @@ defmodule Dataloader.EctoTest do
     assert message =~ "Cardinality"
   end
 
-  describe "has_many through:" do
+  describe "many_to_many" do
     test "basic loading works", %{loader: loader} do
       user1 = %User{username: "Ben Wilson"} |> Repo.insert!()
       user2 = %User{username: "Bruce Williams"} |> Repo.insert!()

--- a/test/support/post.ex
+++ b/test/support/post.ex
@@ -5,7 +5,7 @@ defmodule Dataloader.Post do
     belongs_to(:user, Dataloader.User)
     has_many(:likes, Dataloader.Like)
     has_many(:scores, Dataloader.Score)
-    has_many(:liking_users, through: [:likes, :user])
+    many_to_many(:liking_users, Dataloader.User, join_through: Dataloader.Like)
 
     field(:title, :string)
     field(:status, :string)


### PR DESCRIPTION
https://github.com/absinthe-graphql/dataloader/pull/144 introduced an effort to ensure that when a `has_many through` association was queried from dataloader, the order specified in dataloader is preserved.

Unfortunately per comments on that PR, this introduced some of its own bugs, and wrapping _any_ order by in an a lateral join had problematic performance regressions. https://github.com/absinthe-graphql/dataloader/issues/165 also seems related to this.

This PR reverts that change, and alters the relevant test case in Dataloader to use a `many_to_many` which does show the order preserving properties.