### PR TITLE
Raise when primary keys in Ecto are nils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Bug Fix: Raise error when primary keys in Ecto struct are nils. This prevents cases when dataloader is loading incorrect associations because of lack of primary key available. ([#177](https://github.com/absinthe-graphql/dataloader/pull/177))
+
 ## v2.0.1 2024-09-04
 
 - Bug Fix: Revert undesirable lateral ([#171](https://github.com/absinthe-graphql/dataloader/pull/171))

--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -519,7 +519,12 @@ if Code.ensure_loaded?(Ecto) do
             |> :erlang.term_to_iovec()
             |> :erlang.md5()
           else
-            Enum.map(primary_keys, &Map.get(record, &1))
+            Enum.map(primary_keys, fn key ->
+              case Map.get(record, key) do
+                nil -> raise "Key #{inspect(key)} is nil for record #{inspect(record)}."
+                value -> value
+              end
+            end)
           end
 
         queryable = chase_down_queryable([assoc_field], schema)

--- a/test/dataloader/ecto_test.exs
+++ b/test/dataloader/ecto_test.exs
@@ -477,6 +477,20 @@ defmodule Dataloader.EctoTest do
     end
   end
 
+  test "when a primary key value is nil it raises an error", %{loader: loader} do
+    %User{username: "Robert Lewandowski"} |> Repo.insert!()
+
+    user_with_nil_id =
+      from(u in User, select: [:username], where: u.username == "Robert Lewandowski")
+      |> Repo.one()
+
+    assert_raise RuntimeError, ~r/Key :id is nil for record/, fn ->
+      loader
+      |> Dataloader.load(Test, :posts, user_with_nil_id)
+      |> Dataloader.run()
+    end
+  end
+
   test "when dataloader times out it raises an error" do
     user =
       %User{username: "Ben Wilson"}


### PR DESCRIPTION
In some cases, when we have an Ecto payload, primary key can be set to nil. This can lead to situation where dataloader is associating the incorrect child object to a parent object. (See the issue here: https://github.com/absinthe-graphql/dataloader/issues/172).

This helps to avoid overlooking such situations by raising when nil was found in primary keys.