### PR TITLE
fix: has_many through loses order_bys

### DIFF
--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -702,8 +702,14 @@ if Code.ensure_loaded?(Ecto) do
         empty = schema |> struct |> Map.fetch!(field)
         records = records |> Enum.map(&Map.put(&1, field, empty))
 
+        is_through_assoc? =
+          case schema.__schema__(:association, field) do
+            %Ecto.Association.HasThrough{} -> true
+            _ -> false
+          end
+
         results =
-          if query.limit || query.offset do
+          if query.limit || query.offset || is_through_assoc? do
             records
             |> preload_lateral(field, query, source.repo, repo_opts)
           else

--- a/priv/test_repo/migrations/1_migrate_all.exs
+++ b/priv/test_repo/migrations/1_migrate_all.exs
@@ -39,6 +39,7 @@ defmodule Dataloader.Ecto.TestRepo.Migrations.MigrateAll do
       add :post_id, references(:posts)
       add :picture_id, references(:pictures)
       add :status, :string
+      add :inserted_at, :utc_datetime_usec
     end
 
     create table(:countries) do

--- a/test/dataloader/ecto_test.exs
+++ b/test/dataloader/ecto_test.exs
@@ -445,7 +445,28 @@ defmodule Dataloader.EctoTest do
     end
   end
 
-  describe "has_many through" do
+  describe "has_many" do
+    test "order_by works for has_many associations", %{loader: loader} do
+      user = %User{username: "Test User"} |> Repo.insert!()
+
+      # This seems odd, but we set ids on purpose here since our query sorts by
+      # them This is to show how the order returned below is not based on
+      # anything other than the id
+      post3 = %Post{id: 3, user_id: user.id, title: "Third Post"} |> Repo.insert!()
+      post2 = %Post{id: 2, user_id: user.id, title: "Second Post"} |> Repo.insert!()
+      post1 = %Post{id: 1, user_id: user.id, title: "First Post"} |> Repo.insert!()
+
+      loader =
+        loader
+        |> Dataloader.load(Test, :posts, user)
+        |> Dataloader.run()
+
+      posts = Dataloader.get(loader, Test, :posts, user)
+
+      # Post query uses order_by(asc: :id), so we get the ascending order
+      assert Enum.map(posts, & &1.id) == [post1.id, post2.id, post3.id]
+    end
+
     test "order_by works for has_many through associations", %{loader: loader} do
       user = %User{username: "Test User"} |> Repo.insert!()
 

--- a/test/dataloader/ecto_test.exs
+++ b/test/dataloader/ecto_test.exs
@@ -450,8 +450,8 @@ defmodule Dataloader.EctoTest do
       user = %User{username: "Test User"} |> Repo.insert!()
 
       # This seems odd, but we set ids on purpose here since our query sorts by
-      # them This is to show how the order returned below is not based on
-      # anything other than the id
+      # them. This is to show how the order returned below is not based on
+      # anything other than the sorted id
       post3 = %Post{id: 3, user_id: user.id, title: "Third Post"} |> Repo.insert!()
       post2 = %Post{id: 2, user_id: user.id, title: "Second Post"} |> Repo.insert!()
       post1 = %Post{id: 1, user_id: user.id, title: "First Post"} |> Repo.insert!()

--- a/test/support/like.ex
+++ b/test/support/like.ex
@@ -6,5 +6,6 @@ defmodule Dataloader.Like do
     belongs_to(:post, Dataloader.Post, where: [status: "published"])
     belongs_to(:picture, Dataloader.Picture)
     field(:status, :string)
+    field(:inserted_at, :utc_datetime_usec)
   end
 end

--- a/test/support/user.ex
+++ b/test/support/user.ex
@@ -5,6 +5,7 @@ defmodule Dataloader.User do
     field(:username, :string)
     has_many(:posts, Dataloader.Post)
     has_many(:published_posts, Dataloader.Post, where: [status: "published"])
+    has_many(:posts_likes, through: [:posts, :likes])
     has_many(:published_posts_likes, through: [:published_posts, :likes])
     belongs_to(:leaderboard, Dataloader.Leaderboard)
 


### PR DESCRIPTION
Hi @benwilson512!

Thanks for all of your work in the community! ❤️ 

I think there is a small bug in `has_many through` associations. They end up losing `order_by`s. `many_to_many` works as expected. I was going to create an issue for this, but found this one https://github.com/absinthe-graphql/dataloader/issues/169.

Seems like this commit may have caused it -> https://github.com/absinthe-graphql/dataloader/commit/37cd17f761127b83c7c58e1a5848cdae7646514b, but there seems to be some work around that time, maybe it was something else that did it.

In this PR:
- the first commit shows how ordering IS preserved in many_to_many cases.
- the second adds a failing test that shows how `has_many through` is no longer sorted
- the third adds a test to prove that has_many (not through) sorts as expected
- the fourth, tries to solve the issue.

Please let me know if this makes sense to you. Dataloader is new to me, I'm trying to wrap my head around it.

The fix works as expected, there is already code that handles `distinct` correctly (I ran into some errors with this in application code), so this could potentially be a way of fixing this.

Note: This could totally be a me thing, not understanding how to use Dataloader correctly, but once I was able to create the failing tests it started to convince me.

Thank you
